### PR TITLE
Error in subroutine print_classification_data

### DIFF
--- a/Coupling_evaluation.f90
+++ b/Coupling_evaluation.f90
@@ -997,7 +997,7 @@ contains
                            icoupling)%states(istate)%csf%iM2(2),1,1000)
                            number_5 =                                  &
                            JTHN(all_classifications%couplings(         &
-                           icoupling)%states(istate)%csf%iM2(3),1,1000)
+                           icoupling)%states(istate)%csf%iM2(3),2,1000)
                            number_6 =                                  &
                            JTHN(all_classifications%couplings(         &
                            icoupling)%states(istate)%csf%iM2(3),1,1000)


### PR DESCRIPTION
I have fixed the error for printing in case
>Default settings ? (Y/N)'
N

The error was in the subroutine print_classification_data(iwrite). 

You can check this with the test cases from source of program.
For the case
>Default settings ? (Y/N)'
Y
program is running well. But for 
>Default settings ? (Y/N)'
N
it sometimes ops with ERROR.
